### PR TITLE
Adds basic pagination for users, doctors, patients, etc.

### DIFF
--- a/.vscode/graphql.code-snippets
+++ b/.vscode/graphql.code-snippets
@@ -1,0 +1,17 @@
+{
+    "Connection": {
+        "prefix": "conn",
+        "body": [
+            "type $1Edge {",
+            "    cursor: String!",
+            "    node: $1",
+            "}",
+            "",
+            "type ${2:$1s}Connection {",
+            "    pageInfo: PageInfo!",
+            "    edges: [$1Edge]",
+            "}",
+        ],
+        "description": "Creates a Component"
+    },
+}

--- a/.vscode/typescript.code-snippets
+++ b/.vscode/typescript.code-snippets
@@ -39,7 +39,7 @@
             "import { ObjectID } from 'mongodb';",
             "import { buildId } from 'utils/ids';",
             "",
-            "type ${TM_FILENAME_BASE/.*/${0:/capitalize}/}Input = I${TM_FILENAME_BASE/.*/${0:/capitalize}/} | string | ObjectID",
+            "export type ${TM_FILENAME_BASE/.*/${0:/capitalize}/}Input = I${TM_FILENAME_BASE/.*/${0:/capitalize}/} | string | ObjectID",
             "",
             "function getId(input: ${TM_FILENAME_BASE/.*/${0:/capitalize}/}Input): string {",
             "    if (typeof input === 'string') {",

--- a/codegen.yml
+++ b/codegen.yml
@@ -36,3 +36,16 @@ generates:
         Followup: models/Followup#IFollowup
         Review: shims/review#Review
         Service: shims/service#Service
+        PageInfo: pagination#PageInfo
+        ReviewsConnection: pagination#ReviewsConnection
+        UsersConnection: pagination#UsersConnection
+        DoctorsConnection: pagination#DoctorsConnection
+        PatientsConnection: pagination#PatientsConnection
+        ServicesConnection: pagination#ServicesConnection
+        AppointmentsConnection: pagination#AppointmentsConnection
+        ReviewEdge: pagination#ReviewEdge
+        UserEdge: pagination#UserEdge
+        DoctorEdge: pagination#DoctorEdge
+        PatientEdge: pagination#PatientEdge
+        ServiceEdge: pagination#ServiceEdge
+        AppointmentEdge: pagination#AppointmentEdge

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^8.6.0",
         "express": "^4.17.1",
         "graphql": "^15.5.0",
+        "graphql-relay": "^0.7.0",
         "graphql-scalars": "^1.9.3",
         "jsonwebtoken": "^8.5.1",
         "keyv": "^3.1.0",
@@ -5319,6 +5320,17 @@
       },
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/graphql-relay": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.7.0.tgz",
+      "integrity": "sha512-P8eS3IbZRhbfbcfud1Q6VPrIru4hchkb15MuOij+WQo9r0chD5NBIxiVjuRE2iG2EMHxIOrZb8LnMe82+YdITA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >= 15.9.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0"
       }
     },
     "node_modules/graphql-request": {
@@ -14395,6 +14407,12 @@
         "apollo-server-env": "^3.1.0",
         "apollo-server-types": "^0.9.0"
       }
+    },
+    "graphql-relay": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.7.0.tgz",
+      "integrity": "sha512-P8eS3IbZRhbfbcfud1Q6VPrIru4hchkb15MuOij+WQo9r0chD5NBIxiVjuRE2iG2EMHxIOrZb8LnMe82+YdITA==",
+      "requires": {}
     },
     "graphql-request": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dotenv": "^8.6.0",
     "express": "^4.17.1",
     "graphql": "^15.5.0",
+    "graphql-relay": "^0.7.0",
     "graphql-scalars": "^1.9.3",
     "jsonwebtoken": "^8.5.1",
     "keyv": "^3.1.0",

--- a/src/pagination/connection.ts
+++ b/src/pagination/connection.ts
@@ -8,13 +8,15 @@ import { connectionFromArray } from 'graphql-relay';
 
 export type ConnectionQuery<T extends Document, S = never> = Query<T[], T> | T[] | S[]
 
+const DEFAULT_PAGE_SIZE = 20;
+
 export async function connectionFrom<T extends Document, O, S = never>(
     query: ConnectionQuery<T, S>,
     args: ConnectionArguments,
     mapper: (node: T | S) => O,
 ): Promise<Connection<O>> {
     if ('_mongooseOptions' in query) {
-        return await connectionFromMongooseQuery(query, args, mapper);
+        return await connectionFromMongooseQuery(query, args, mapper, DEFAULT_PAGE_SIZE);
     }
     
     const array = query.map(mapper);

--- a/src/pagination/connection.ts
+++ b/src/pagination/connection.ts
@@ -1,0 +1,22 @@
+
+import type { Connection, ConnectionArguments } from 'graphql-relay';
+import type { Document, Query } from 'mongoose';
+
+import { connectionFromMongooseQuery } from './query';
+
+import { connectionFromArray } from 'graphql-relay';
+
+export type ConnectionQuery<T extends Document, S = never> = Query<T[], T> | T[] | S[]
+
+export async function connectionFrom<T extends Document, O, S = never>(
+    query: ConnectionQuery<T, S>,
+    args: ConnectionArguments,
+    mapper: (node: T | S) => O,
+): Promise<Connection<O>> {
+    if ('_mongooseOptions' in query) {
+        return await connectionFromMongooseQuery(query, args, mapper);
+    }
+    
+    const array = query.map(mapper);
+    return connectionFromArray(array, args);
+}

--- a/src/pagination/cursors.ts
+++ b/src/pagination/cursors.ts
@@ -1,0 +1,11 @@
+
+const PREFIX = 'mongodbconnection:';
+
+export function offsetToCursor(offset: number): string {
+    return Buffer.from(PREFIX + offset, 'ascii').toString('base64');
+}
+
+export function cursorToOffset(cursor: string) {
+    const decoded = Buffer.from(cursor, 'base64').toString('ascii');
+    return parseInt(decoded.substring(PREFIX.length, 10));
+}

--- a/src/pagination/cursors.ts
+++ b/src/pagination/cursors.ts
@@ -7,5 +7,5 @@ export function offsetToCursor(offset: number): string {
 
 export function cursorToOffset(cursor: string) {
     const decoded = Buffer.from(cursor, 'base64').toString('ascii');
-    return parseInt(decoded.substring(PREFIX.length, 10));
+    return parseInt(decoded.substring(PREFIX.length));
 }

--- a/src/pagination/index.ts
+++ b/src/pagination/index.ts
@@ -1,6 +1,11 @@
 
 import type { ConnectionQuery } from './connection';
-import type { Connection, ConnectionArguments } from 'graphql-relay';
+import type {
+    Connection,
+    ConnectionArguments,
+    Edge,
+    PageInfo as RelayPageInfo,
+} from 'graphql-relay';
 import type { IAppointment } from 'models/Appointment';
 import type { IDoctor } from 'models/Doctor';
 import type { IPatient } from 'models/Patient';
@@ -21,12 +26,20 @@ import { Review } from 'shims/review';
 import { Service } from 'shims/service';
 import { User } from 'shims/user';
 
+export type PageInfo = RelayPageInfo;
 export type ReviewsConnection = Connection<Review>
 export type UsersConnection = Connection<User>
 export type DoctorsConnection = Connection<Doctor>
 export type PatientsConnection = Connection<Patient>
 export type ServicesConnection = Connection<Service>
 export type AppointmentsConnection = Connection<IAppointment>
+
+export type ReviewEdge = Edge<Review>
+export type UserEdge = Edge<User>
+export type DoctorEdge = Edge<Doctor>
+export type PatientEdge = Edge<Patient>
+export type ServiceEdge = Edge<Service>
+export type AppointmentEdge = Edge<IAppointment>
 
 export async function reviewsConnection(
     query: ConnectionQuery<IReview, ReviewInput>,

--- a/src/pagination/index.ts
+++ b/src/pagination/index.ts
@@ -1,0 +1,71 @@
+
+import type { ConnectionQuery } from './connection';
+import type { Connection, ConnectionArguments } from 'graphql-relay';
+import type { IAppointment } from 'models/Appointment';
+import type { IDoctor } from 'models/Doctor';
+import type { IPatient } from 'models/Patient';
+import type { IReview } from 'models/Review';
+import type { IService } from 'models/Service';
+import type { IUser } from 'models/User';
+import type { DoctorInput } from 'shims/doctor';
+import type { PatientInput } from 'shims/patient';
+import type { ReviewInput } from 'shims/review';
+import type { ServiceInput } from 'shims/service';
+import type { UserInput } from 'shims/user';
+
+import { connectionFrom } from './connection';
+
+import { Doctor } from 'shims/doctor';
+import { Patient } from 'shims/patient';
+import { Review } from 'shims/review';
+import { Service } from 'shims/service';
+import { User } from 'shims/user';
+
+export type ReviewsConnection = Connection<Review>
+export type UsersConnection = Connection<User>
+export type DoctorsConnection = Connection<Doctor>
+export type PatientsConnection = Connection<Patient>
+export type ServicesConnection = Connection<Service>
+export type AppointmentsConnection = Connection<IAppointment>
+
+export async function reviewsConnection(
+    query: ConnectionQuery<IReview, ReviewInput>,
+    args: ConnectionArguments,
+): Promise<ReviewsConnection> {
+    return await connectionFrom(query, args, node => new Review(node));
+}
+
+export async function usersConnection(
+    query: ConnectionQuery<IUser, UserInput>,
+    args: ConnectionArguments,
+): Promise<UsersConnection> {
+    return await connectionFrom(query, args, node => new User(node));
+}
+
+export async function doctorsConnection(
+    query: ConnectionQuery<IDoctor, DoctorInput>,
+    args: ConnectionArguments,
+): Promise<DoctorsConnection> {
+    return await connectionFrom(query, args, node => new Doctor(node));
+}
+
+export async function servicesConnection(
+    query: ConnectionQuery<IService, ServiceInput>,
+    args: ConnectionArguments,
+): Promise<ServicesConnection> {
+    return await connectionFrom(query, args, node => new Service(node));
+}
+
+export async function patientsConnection(
+    query: ConnectionQuery<IPatient, PatientInput>,
+    args: ConnectionArguments,
+): Promise<PatientsConnection> {
+    return await connectionFrom(query, args, node => new Patient(node));
+}
+
+export async function appointmentsConnection(
+    query: ConnectionQuery<IAppointment>,
+    args: ConnectionArguments,
+): Promise<AppointmentsConnection> {
+    return await connectionFrom(query, args, node => node);
+}

--- a/src/pagination/offsets.ts
+++ b/src/pagination/offsets.ts
@@ -16,6 +16,7 @@ export function getOffsetWithDefault(
 export function getOffsetsFromArgs(
     { after, before, first, last }: ConnectionArguments,
     count: number,
+    defaultPageSize?: number,
 ) {
     const beforeOffset = getOffsetWithDefault(before, count);
     const afterOffset = getOffsetWithDefault(after, -1);
@@ -28,6 +29,14 @@ export function getOffsetsFromArgs(
     }
     if (last != null) {
         startOffset = Math.max(startOffset, endOffset - last);
+    }
+
+    if (first == null && last == null && defaultPageSize != null) {
+        if (before != null) {
+            startOffset = Math.max(startOffset, endOffset - defaultPageSize);
+        } else {
+            endOffset = Math.min(endOffset, startOffset + defaultPageSize);
+        }
     }
 
     const skip = Math.max(startOffset, 0);

--- a/src/pagination/offsets.ts
+++ b/src/pagination/offsets.ts
@@ -1,0 +1,44 @@
+import type { ConnectionArguments } from 'graphql-relay';
+
+import { cursorToOffset } from './cursors';
+
+export function getOffsetWithDefault(
+    cursor: string | null | undefined,
+    defaultOffset: number,
+) {
+    if (cursor == null) {
+        return defaultOffset;
+    }
+    const offset = cursorToOffset(cursor);
+    return isNaN(offset) ? defaultOffset : offset;
+}
+
+export function getOffsetsFromArgs(
+    { after, before, first, last }: ConnectionArguments,
+    count: number,
+) {
+    const beforeOffset = getOffsetWithDefault(before, count);
+    const afterOffset = getOffsetWithDefault(after, -1);
+
+    let startOffset = Math.max(-1, afterOffset) + 1;
+    let endOffset = Math.min(count, beforeOffset);
+
+    if (first != null) {
+        endOffset = Math.min(endOffset, startOffset + first);
+    }
+    if (last != null) {
+        startOffset = Math.max(startOffset, endOffset - last);
+    }
+
+    const skip = Math.max(startOffset, 0);
+    const limit = endOffset - startOffset;
+
+    return {
+        afterOffset: afterOffset,
+        beforeOffset: beforeOffset,
+        endOffset: endOffset,
+        limit: limit,
+        skip: skip,
+        startOffset: startOffset,
+    };
+}

--- a/src/pagination/query.ts
+++ b/src/pagination/query.ts
@@ -1,0 +1,28 @@
+
+import type { Connection, ConnectionArguments } from 'graphql-relay';
+import type { Document, Query } from 'mongoose';
+
+import { getOffsetsFromArgs } from './offsets';
+import { getConnectionFromSlice } from './slicing';
+
+export async function connectionFromMongooseQuery<T extends Document, O>(
+    query: Query<T[], T>,
+    args: ConnectionArguments,
+    mapper: (node: T) => O,
+): Promise<Connection<O>> {
+    const count = await query.count();
+    const pagination = getOffsetsFromArgs(args, count);
+
+    if (pagination.limit === 0) {
+        return getConnectionFromSlice([], mapper, args, count);
+    }
+
+    query.skip(pagination.skip);
+    query.limit(pagination.limit);
+
+    // Convert all Mongoose documents to objects
+    query.lean();
+
+    const slice = await query.find();
+    return getConnectionFromSlice(slice, mapper, args, count);
+}

--- a/src/pagination/query.ts
+++ b/src/pagination/query.ts
@@ -9,12 +9,13 @@ export async function connectionFromMongooseQuery<T extends Document, O>(
     query: Query<T[], T>,
     args: ConnectionArguments,
     mapper: (node: T) => O,
+    defaultPageSize?: number,
 ): Promise<Connection<O>> {
     const count = await query.count();
-    const pagination = getOffsetsFromArgs(args, count);
+    const pagination = getOffsetsFromArgs(args, count, defaultPageSize);
 
     if (pagination.limit === 0) {
-        return getConnectionFromSlice([], mapper, args, count);
+        return getConnectionFromSlice([], mapper, args, count, defaultPageSize);
     }
 
     query.skip(pagination.skip);
@@ -24,5 +25,5 @@ export async function connectionFromMongooseQuery<T extends Document, O>(
     query.lean();
 
     const slice = await query.find();
-    return getConnectionFromSlice(slice, mapper, args, count);
+    return getConnectionFromSlice(slice, mapper, args, count, defaultPageSize);
 }

--- a/src/pagination/slicing.ts
+++ b/src/pagination/slicing.ts
@@ -10,13 +10,14 @@ export function getConnectionFromSlice<T extends Document, O>(
     mapper: (node: T) => O,
     args: ConnectionArguments,
     count: number,
+    defaultPageSize?: number,
 ) : Connection<O> {
     const first = args.first;
     const last = args.last;
     const before = args.before;
     const after = args.after;
 
-    const offsetsFromArgs = getOffsetsFromArgs(args, count);
+    const offsetsFromArgs = getOffsetsFromArgs(args, count, defaultPageSize);
     const startOffset = offsetsFromArgs.startOffset;
     const endOffset = offsetsFromArgs.endOffset;
     const beforeOffset = offsetsFromArgs.beforeOffset;

--- a/src/pagination/slicing.ts
+++ b/src/pagination/slicing.ts
@@ -2,9 +2,8 @@
 import type { Connection, ConnectionArguments } from 'graphql-relay';
 import type { Document } from 'mongoose';
 
+import { offsetToCursor } from './cursors';
 import { getOffsetsFromArgs } from './offsets';
-
-import { offsetToCursor } from 'graphql-relay';
 
 export function getConnectionFromSlice<T extends Document, O>(
     slice: T[],

--- a/src/pagination/slicing.ts
+++ b/src/pagination/slicing.ts
@@ -1,0 +1,47 @@
+
+import type { Connection, ConnectionArguments } from 'graphql-relay';
+import type { Document } from 'mongoose';
+
+import { getOffsetsFromArgs } from './offsets';
+
+import { offsetToCursor } from 'graphql-relay';
+
+export function getConnectionFromSlice<T extends Document, O>(
+    slice: T[],
+    mapper: (node: T) => O,
+    args: ConnectionArguments,
+    count: number,
+) : Connection<O> {
+    const first = args.first;
+    const last = args.last;
+    const before = args.before;
+    const after = args.after;
+
+    const offsetsFromArgs = getOffsetsFromArgs(args, count);
+    const startOffset = offsetsFromArgs.startOffset;
+    const endOffset = offsetsFromArgs.endOffset;
+    const beforeOffset = offsetsFromArgs.beforeOffset;
+    const afterOffset = offsetsFromArgs.afterOffset;
+
+    const edges = slice.map((node, index) => {
+        return {
+            cursor: offsetToCursor(startOffset + index),
+            node: mapper(node),
+        };
+    });
+
+    const firstEdge = edges[0];
+    const lastEdge = edges[edges.length - 1];
+    const lowerBound = after ? afterOffset + 1 : 0;
+    const upperBound = before ? Math.min(beforeOffset, count) : count;
+
+    return {
+        edges: edges,
+        pageInfo: {
+            endCursor: lastEdge ? lastEdge.cursor : null,
+            hasNextPage: first != null ? endOffset < upperBound : false,
+            hasPreviousPage: last != null ? startOffset > lowerBound : false,
+            startCursor: firstEdge ? firstEdge.cursor : null,
+        },
+    };
+}

--- a/src/resolvers/connections.ts
+++ b/src/resolvers/connections.ts
@@ -1,0 +1,73 @@
+
+import type {
+    AppointmentEdgeResolvers,
+    AppointmentsConnectionResolvers,
+    DoctorEdgeResolvers,
+    DoctorsConnectionResolvers,
+    PageInfoResolvers,
+    PatientEdgeResolvers,
+    PatientsConnectionResolvers,
+    ReviewEdgeResolvers,
+    ReviewsConnectionResolvers,
+    ServiceEdgeResolvers,
+    ServicesConnectionResolvers,
+    UserEdgeResolvers,
+    UsersConnectionResolvers,
+} from '@resolvers';
+import type { Edge } from 'graphql-relay';
+import type { Connection } from 'graphql-relay';
+
+export const PageInfo: PageInfoResolvers = {
+    endCursor({ endCursor }) {
+        return endCursor;
+    },
+    hasNextPage({ hasNextPage }) {
+        return hasNextPage;
+    },
+    hasPreviousPage({ hasPreviousPage }) {
+        return hasPreviousPage;
+    },
+    startCursor({ startCursor }) {
+        return startCursor;
+    },
+};
+
+function edgeResolvers<T>() {
+    return {
+        cursor({ cursor }: Edge<T>) {
+            return cursor;
+        },
+        node({ node }: Edge<T>) {
+            return node;
+        },
+    };
+}
+
+function connectionResolvers<T>() {
+    return {
+        edges({ edges }: Connection<T>) {
+            return edges;
+        },
+        pageInfo({ pageInfo }: Connection<T>) {
+            return pageInfo;
+        },
+    };
+}
+
+export const ReviewEdge: ReviewEdgeResolvers = edgeResolvers();
+export const ReviewsConnection: ReviewsConnectionResolvers = connectionResolvers();
+
+export const UserEdge: UserEdgeResolvers = edgeResolvers();
+export const UsersConnection: UsersConnectionResolvers = connectionResolvers();
+
+export const DoctorEdge: DoctorEdgeResolvers = edgeResolvers();
+export const DoctorsConnection: DoctorsConnectionResolvers = connectionResolvers();
+
+export const PatientEdge: PatientEdgeResolvers = edgeResolvers();
+export const PatientsConnection: PatientsConnectionResolvers = connectionResolvers();
+
+export const ServiceEdge: ServiceEdgeResolvers = edgeResolvers();
+export const ServicesConnection: ServicesConnectionResolvers = connectionResolvers();
+
+export const AppointmentEdge: AppointmentEdgeResolvers = edgeResolvers();
+export const AppointmentsConnection: AppointmentsConnectionResolvers = connectionResolvers();

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -6,6 +6,21 @@ import Address from './address';
 import Appointment from './appointment';
 import AppointmentTime from './appointmentTime';
 import Checkup from './checkup';
+import {
+    AppointmentEdge,
+    AppointmentsConnection,
+    DoctorEdge,
+    DoctorsConnection,
+    PageInfo,
+    PatientEdge,
+    PatientsConnection,
+    ReviewEdge,
+    ReviewsConnection,
+    ServiceEdge,
+    ServicesConnection,
+    UserEdge,
+    UsersConnection,
+} from './connections';
 import Doctor from './doctor';
 import Followup from './followup';
 import Gender from './gender';
@@ -32,10 +47,14 @@ const resolvers: Resolvers = {
     ActivityLevel,
     Address,
     Appointment,
+    AppointmentEdge,
     AppointmentTime,
+    AppointmentsConnection,
     Checkup,
     DateTime,
     Doctor,
+    DoctorEdge,
+    DoctorsConnection,
     Duration,
     Followup,
     Gender,
@@ -43,13 +62,22 @@ const resolvers: Resolvers = {
     Length,
     Node,
     OfferedSlot,
+    PageInfo,
     Patient,
+    PatientEdge,
+    PatientsConnection,
     Query,
     Review,
+    ReviewEdge,
+    ReviewsConnection,
     Service,
+    ServiceEdge,
+    ServicesConnection,
     Time,
     URL,
     User,
+    UserEdge,
+    UsersConnection,
     Weekday,
     Weight,
 };

--- a/src/resolvers/query.ts
+++ b/src/resolvers/query.ts
@@ -3,7 +3,19 @@ import type { QueryResolvers } from '@resolvers';
 
 import Appointment from 'models/Appointment';
 import Checkup from 'models/Checkup';
+import Doctor from 'models/Doctor';
 import Followup from 'models/Followup';
+import Patient from 'models/Patient';
+import Review from 'models/Review';
+import Service from 'models/Service';
+import User from 'models/User';
+import {
+    doctorsConnection,
+    patientsConnection,
+    reviewsConnection,
+    servicesConnection,
+    usersConnection,
+} from 'pagination';
 import { doctor } from 'shims/doctor';
 import { patient } from 'shims/patient';
 import { review } from 'shims/review';
@@ -12,6 +24,9 @@ import { user } from 'shims/user';
 import { deconstructId } from 'utils/ids';
 
 const Query: QueryResolvers = {
+    async doctors(_, args) {
+        return await doctorsConnection(Doctor.find(), args);
+    },
     greeting(_0, _1, { authenticated }) {
         if (authenticated != null) {
             return `Hello, User ${authenticated.id()}`;
@@ -48,6 +63,18 @@ const Query: QueryResolvers = {
         case 'User':
             return await user(id);
         }
+    },
+    async patients(_, args) {
+        return await patientsConnection(Patient.find(), args);
+    },
+    async reviews(_, args) {
+        return await reviewsConnection(Review.find(), args);
+    },
+    async services(_, args) {
+        return await servicesConnection(Service.find(), args);
+    },
+    async users(_, args) {
+        return await usersConnection(User.find(), args);
     },
 };
 

--- a/src/shims/doctor.ts
+++ b/src/shims/doctor.ts
@@ -8,7 +8,7 @@ import User from 'models/User';
 import { ObjectID } from 'mongodb';
 import { buildId } from 'utils/ids';
 
-type DoctorInput = IDoctor | FollowupDoctor | AppointmentDoctor | string | ObjectID
+export type DoctorInput = IDoctor | FollowupDoctor | AppointmentDoctor | string | ObjectID
 
 function getId(input: DoctorInput): string {
     if (typeof input === 'string') {

--- a/src/shims/patient.ts
+++ b/src/shims/patient.ts
@@ -11,7 +11,8 @@ import User from 'models/User';
 import { ObjectID } from 'mongodb';
 import { buildId } from 'utils/ids';
 
-type PatientInput = IPatient | AppointmentPatient | CheckupPatient | FollowupPatient | ReviewPatient | string | ObjectID
+export type PatientInput =
+    IPatient | AppointmentPatient | CheckupPatient | FollowupPatient | ReviewPatient | string | ObjectID
 
 function getId(input: PatientInput): string {
     if (typeof input === 'string') {

--- a/src/shims/review.ts
+++ b/src/shims/review.ts
@@ -5,7 +5,7 @@ import ReviewModel from 'models/Review';
 import { ObjectID } from 'mongodb';
 import { buildId } from 'utils/ids';
 
-type ReviewInput = IReview | IMiniReview | string | ObjectID
+export type ReviewInput = IReview | IMiniReview | string | ObjectID
 
 function getId(input: ReviewInput): string {
     if (typeof input === 'string') {

--- a/src/shims/service.ts
+++ b/src/shims/service.ts
@@ -6,7 +6,7 @@ import ServiceModel from 'models/Service';
 import { ObjectID } from 'mongodb';
 import { buildId } from 'utils/ids';
 
-type ServiceInput = IService | DoctorService | AppointmentService | string | ObjectID
+export type ServiceInput = IService | DoctorService | AppointmentService | string | ObjectID
 
 function getId(input: ServiceInput): string {
     if (typeof input === 'string') {

--- a/src/shims/user.ts
+++ b/src/shims/user.ts
@@ -4,7 +4,7 @@ import UserModel from 'models/User';
 import { ObjectID } from 'mongodb';
 import { buildId } from 'utils/ids';
 
-type UserInput = IUser | string | ObjectID
+export type UserInput = IUser | string | ObjectID
 
 function getId(input: UserInput): string {
     if (typeof input === 'string') {

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -166,6 +166,73 @@ export const typeDefs = gql`
         patientProfile: Patient
     }
 
+    type PageInfo {
+        hasNextPage: Boolean!
+        hasPreviousPage: Boolean!
+        startCursor: String
+        endCursor: String
+    }
+
+    type UserEdge {
+        cursor: String!
+        node: User
+    }
+    
+    type UsersConnection {
+        pageInfo: PageInfo!
+        edges: [UserEdge]
+    }
+
+    type ReviewEdge {
+        cursor: String!
+        node: Review
+    }
+    
+    type ReviewsConnection {
+        pageInfo: PageInfo!
+        edges: [ReviewEdge]
+    }
+
+    type DoctorEdge {
+        cursor: String!
+        node: Doctor
+    }
+    
+    type DoctorsConnection {
+        pageInfo: PageInfo!
+        edges: [DoctorEdge]
+    }
+
+    type PatientEdge {
+        cursor: String!
+        node: Patient
+    }
+    
+    type PatientsConnection {
+        pageInfo: PageInfo!
+        edges: [PatientEdge]
+    }
+
+    type ServiceEdge {
+        cursor: String!
+        node: Service
+    }
+    
+    type ServicesConnection {
+        pageInfo: PageInfo!
+        edges: [ServiceEdge]
+    }
+
+    type AppointmentEdge {
+        cursor: String!
+        node: Appointment
+    }
+    
+    type AppointmentsConnection {
+        pageInfo: PageInfo!
+        edges: [AppointmentEdge]
+    }
+
     type Query {
         greeting: String!
         me: User

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -237,6 +237,12 @@ export const typeDefs = gql`
         greeting: String!
         me: User
         node(id: ID!): Node
+
+        users(after: String, first: Int, before: String, last: Int): UsersConnection
+        patients(after: String, first: Int, before: String, last: Int): PatientsConnection
+        doctors(after: String, first: Int, before: String, last: Int): DoctorsConnection
+        reviews(after: String, first: Int, before: String, last: Int): ReviewsConnection
+        services(after: String, first: Int, before: String, last: Int): ServicesConnection
     }
 
     schema {

--- a/src/utils/resolvers.ts
+++ b/src/utils/resolvers.ts
@@ -176,11 +176,56 @@ export type Query = {
   readonly greeting: Scalars['String'];
   readonly me: Maybe<User>;
   readonly node: Maybe<Node>;
+  readonly users: Maybe<UsersConnection>;
+  readonly patients: Maybe<PatientsConnection>;
+  readonly doctors: Maybe<DoctorsConnection>;
+  readonly reviews: Maybe<ReviewsConnection>;
+  readonly services: Maybe<ServicesConnection>;
 };
 
 
 export type QueryNodeArgs = {
   id: Scalars['ID'];
+};
+
+
+export type QueryUsersArgs = {
+  after: Maybe<Scalars['String']>;
+  first: Maybe<Scalars['Int']>;
+  before: Maybe<Scalars['String']>;
+  last: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryPatientsArgs = {
+  after: Maybe<Scalars['String']>;
+  first: Maybe<Scalars['Int']>;
+  before: Maybe<Scalars['String']>;
+  last: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryDoctorsArgs = {
+  after: Maybe<Scalars['String']>;
+  first: Maybe<Scalars['Int']>;
+  before: Maybe<Scalars['String']>;
+  last: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryReviewsArgs = {
+  after: Maybe<Scalars['String']>;
+  first: Maybe<Scalars['Int']>;
+  before: Maybe<Scalars['String']>;
+  last: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryServicesArgs = {
+  after: Maybe<Scalars['String']>;
+  first: Maybe<Scalars['Int']>;
+  before: Maybe<Scalars['String']>;
+  last: Maybe<Scalars['Int']>;
 };
 
 export type Review = Node & {
@@ -560,6 +605,11 @@ export type QueryResolvers<ContextType = Context, ParentType extends ResolversPa
   greeting: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   me: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   node: Resolver<Maybe<ResolversTypes['Node']>, ParentType, ContextType, RequireFields<QueryNodeArgs, 'id'>>;
+  users: Resolver<Maybe<ResolversTypes['UsersConnection']>, ParentType, ContextType, RequireFields<QueryUsersArgs, never>>;
+  patients: Resolver<Maybe<ResolversTypes['PatientsConnection']>, ParentType, ContextType, RequireFields<QueryPatientsArgs, never>>;
+  doctors: Resolver<Maybe<ResolversTypes['DoctorsConnection']>, ParentType, ContextType, RequireFields<QueryDoctorsArgs, never>>;
+  reviews: Resolver<Maybe<ResolversTypes['ReviewsConnection']>, ParentType, ContextType, RequireFields<QueryReviewsArgs, never>>;
+  services: Resolver<Maybe<ResolversTypes['ServicesConnection']>, ParentType, ContextType, RequireFields<QueryServicesArgs, never>>;
 }>;
 
 export type ReviewResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Review'] = ResolversParentTypes['Review']> = ResolversObject<{

--- a/src/utils/resolvers.ts
+++ b/src/utils/resolvers.ts
@@ -10,6 +10,7 @@ import type { ICheckup as ICheckupModel } from 'models/Checkup';
 import type { IFollowup as IFollowupModel } from 'models/Followup';
 import type { Review as ReviewModel } from 'shims/review';
 import type { Service as ServiceModel } from 'shims/service';
+import type { PageInfo as PageInfoModel, ReviewsConnection as ReviewsConnectionModel, UsersConnection as UsersConnectionModel, DoctorsConnection as DoctorsConnectionModel, PatientsConnection as PatientsConnectionModel, ServicesConnection as ServicesConnectionModel, AppointmentsConnection as AppointmentsConnectionModel, ReviewEdge as ReviewEdgeModel, UserEdge as UserEdgeModel, DoctorEdge as DoctorEdgeModel, PatientEdge as PatientEdgeModel, ServiceEdge as ServiceEdgeModel, AppointmentEdge as AppointmentEdgeModel } from 'pagination';
 import type { Context } from 'context';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -60,9 +61,19 @@ export type Appointment = Node & {
   readonly selectedServices: ReadonlyArray<Service>;
 };
 
+export type AppointmentEdge = {
+  readonly cursor: Scalars['String'];
+  readonly node: Maybe<Appointment>;
+};
+
 export type AppointmentTime = {
   readonly start: Maybe<Scalars['DateTime']>;
   readonly duration: Maybe<Scalars['Duration']>;
+};
+
+export type AppointmentsConnection = {
+  readonly pageInfo: PageInfo;
+  readonly edges: Maybe<ReadonlyArray<Maybe<AppointmentEdge>>>;
 };
 
 export type Checkup = Node & {
@@ -84,6 +95,16 @@ export type Doctor = Node & {
   readonly topServices: ReadonlyArray<Service>;
   readonly topReviews: ReadonlyArray<Review>;
   readonly webpage: Maybe<Scalars['URL']>;
+};
+
+export type DoctorEdge = {
+  readonly cursor: Scalars['String'];
+  readonly node: Maybe<Doctor>;
+};
+
+export type DoctorsConnection = {
+  readonly pageInfo: PageInfo;
+  readonly edges: Maybe<ReadonlyArray<Maybe<DoctorEdge>>>;
 };
 
 
@@ -119,6 +140,13 @@ export type OfferedSlot = {
   readonly end: Scalars['Time'];
 };
 
+export type PageInfo = {
+  readonly hasNextPage: Scalars['Boolean'];
+  readonly hasPreviousPage: Scalars['Boolean'];
+  readonly startCursor: Maybe<Scalars['String']>;
+  readonly endCursor: Maybe<Scalars['String']>;
+};
+
 export type Patient = Node & {
   readonly id: Scalars['ID'];
   readonly firstname: Scalars['String'];
@@ -132,6 +160,16 @@ export type Patient = Node & {
   readonly allergies: ReadonlyArray<Scalars['String']>;
   readonly surgeries: ReadonlyArray<Scalars['String']>;
   readonly isSmoker: Maybe<Scalars['Boolean']>;
+};
+
+export type PatientEdge = {
+  readonly cursor: Scalars['String'];
+  readonly node: Maybe<Patient>;
+};
+
+export type PatientsConnection = {
+  readonly pageInfo: PageInfo;
+  readonly edges: Maybe<ReadonlyArray<Maybe<PatientEdge>>>;
 };
 
 export type Query = {
@@ -153,8 +191,28 @@ export type Review = Node & {
   readonly content: Maybe<Scalars['String']>;
 };
 
+export type ReviewEdge = {
+  readonly cursor: Scalars['String'];
+  readonly node: Maybe<Review>;
+};
+
+export type ReviewsConnection = {
+  readonly pageInfo: PageInfo;
+  readonly edges: Maybe<ReadonlyArray<Maybe<ReviewEdge>>>;
+};
+
 export type Service = Node & {
   readonly id: Scalars['ID'];
+};
+
+export type ServiceEdge = {
+  readonly cursor: Scalars['String'];
+  readonly node: Maybe<Service>;
+};
+
+export type ServicesConnection = {
+  readonly pageInfo: PageInfo;
+  readonly edges: Maybe<ReadonlyArray<Maybe<ServiceEdge>>>;
 };
 
 
@@ -165,6 +223,16 @@ export type User = Node & {
   readonly lastname: Scalars['String'];
   readonly doctorProfile: Maybe<Doctor>;
   readonly patientProfile: Maybe<Patient>;
+};
+
+export type UserEdge = {
+  readonly cursor: Scalars['String'];
+  readonly node: Maybe<User>;
+};
+
+export type UsersConnection = {
+  readonly pageInfo: PageInfo;
+  readonly edges: Maybe<ReadonlyArray<Maybe<UserEdge>>>;
 };
 
 export enum Weekday {
@@ -264,11 +332,15 @@ export type ResolversTypes = ResolversObject<{
   Appointment: ResolverTypeWrapper<IAppointmentModel>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  AppointmentEdge: ResolverTypeWrapper<AppointmentEdgeModel>;
   AppointmentTime: ResolverTypeWrapper<AppointmentTime>;
+  AppointmentsConnection: ResolverTypeWrapper<AppointmentsConnectionModel>;
   Checkup: ResolverTypeWrapper<ICheckupModel>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
   Doctor: ResolverTypeWrapper<DoctorModel>;
   Float: ResolverTypeWrapper<Scalars['Float']>;
+  DoctorEdge: ResolverTypeWrapper<DoctorEdgeModel>;
+  DoctorsConnection: ResolverTypeWrapper<DoctorsConnectionModel>;
   Duration: ResolverTypeWrapper<Scalars['Duration']>;
   Followup: ResolverTypeWrapper<IFollowupModel>;
   Gender: ResolverTypeWrapper<GenderModel>;
@@ -276,13 +348,22 @@ export type ResolversTypes = ResolversObject<{
   Length: ResolverTypeWrapper<Scalars['Length']>;
   Node: ResolversTypes['Appointment'] | ResolversTypes['Checkup'] | ResolversTypes['Doctor'] | ResolversTypes['Followup'] | ResolversTypes['Patient'] | ResolversTypes['Review'] | ResolversTypes['Service'] | ResolversTypes['User'];
   OfferedSlot: ResolverTypeWrapper<Omit<OfferedSlot, 'day'> & { day: ResolversTypes['Weekday'] }>;
+  PageInfo: ResolverTypeWrapper<PageInfoModel>;
   Patient: ResolverTypeWrapper<PatientModel>;
+  PatientEdge: ResolverTypeWrapper<PatientEdgeModel>;
+  PatientsConnection: ResolverTypeWrapper<PatientsConnectionModel>;
   Query: ResolverTypeWrapper<{}>;
   Review: ResolverTypeWrapper<ReviewModel>;
+  ReviewEdge: ResolverTypeWrapper<ReviewEdgeModel>;
+  ReviewsConnection: ResolverTypeWrapper<ReviewsConnectionModel>;
   Service: ResolverTypeWrapper<ServiceModel>;
+  ServiceEdge: ResolverTypeWrapper<ServiceEdgeModel>;
+  ServicesConnection: ResolverTypeWrapper<ServicesConnectionModel>;
   Time: ResolverTypeWrapper<Scalars['Time']>;
   URL: ResolverTypeWrapper<Scalars['URL']>;
   User: ResolverTypeWrapper<UserModel>;
+  UserEdge: ResolverTypeWrapper<UserEdgeModel>;
+  UsersConnection: ResolverTypeWrapper<UsersConnectionModel>;
   Weekday: ResolverTypeWrapper<DayModel>;
   Weight: ResolverTypeWrapper<Scalars['Weight']>;
 }>;
@@ -295,23 +376,36 @@ export type ResolversParentTypes = ResolversObject<{
   Appointment: IAppointmentModel;
   ID: Scalars['ID'];
   Boolean: Scalars['Boolean'];
+  AppointmentEdge: AppointmentEdgeModel;
   AppointmentTime: AppointmentTime;
+  AppointmentsConnection: AppointmentsConnectionModel;
   Checkup: ICheckupModel;
   DateTime: Scalars['DateTime'];
   Doctor: DoctorModel;
   Float: Scalars['Float'];
+  DoctorEdge: DoctorEdgeModel;
+  DoctorsConnection: DoctorsConnectionModel;
   Duration: Scalars['Duration'];
   Followup: IFollowupModel;
   Length: Scalars['Length'];
   Node: ResolversParentTypes['Appointment'] | ResolversParentTypes['Checkup'] | ResolversParentTypes['Doctor'] | ResolversParentTypes['Followup'] | ResolversParentTypes['Patient'] | ResolversParentTypes['Review'] | ResolversParentTypes['Service'] | ResolversParentTypes['User'];
   OfferedSlot: Omit<OfferedSlot, 'day'> & { day: ResolversParentTypes['Weekday'] };
+  PageInfo: PageInfoModel;
   Patient: PatientModel;
+  PatientEdge: PatientEdgeModel;
+  PatientsConnection: PatientsConnectionModel;
   Query: {};
   Review: ReviewModel;
+  ReviewEdge: ReviewEdgeModel;
+  ReviewsConnection: ReviewsConnectionModel;
   Service: ServiceModel;
+  ServiceEdge: ServiceEdgeModel;
+  ServicesConnection: ServicesConnectionModel;
   Time: Scalars['Time'];
   URL: Scalars['URL'];
   User: UserModel;
+  UserEdge: UserEdgeModel;
+  UsersConnection: UsersConnectionModel;
   Weight: Scalars['Weight'];
 }>;
 
@@ -338,9 +432,21 @@ export type AppointmentResolvers<ContextType = Context, ParentType extends Resol
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type AppointmentEdgeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['AppointmentEdge'] = ResolversParentTypes['AppointmentEdge']> = ResolversObject<{
+  cursor: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes['Appointment']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type AppointmentTimeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['AppointmentTime'] = ResolversParentTypes['AppointmentTime']> = ResolversObject<{
   start: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   duration: Resolver<Maybe<ResolversTypes['Duration']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type AppointmentsConnectionResolvers<ContextType = Context, ParentType extends ResolversParentTypes['AppointmentsConnection'] = ResolversParentTypes['AppointmentsConnection']> = ResolversObject<{
+  pageInfo: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
+  edges: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['AppointmentEdge']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -367,6 +473,18 @@ export type DoctorResolvers<ContextType = Context, ParentType extends ResolversP
   topServices: Resolver<ReadonlyArray<ResolversTypes['Service']>, ParentType, ContextType>;
   topReviews: Resolver<ReadonlyArray<ResolversTypes['Review']>, ParentType, ContextType>;
   webpage: Resolver<Maybe<ResolversTypes['URL']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DoctorEdgeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['DoctorEdge'] = ResolversParentTypes['DoctorEdge']> = ResolversObject<{
+  cursor: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes['Doctor']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type DoctorsConnectionResolvers<ContextType = Context, ParentType extends ResolversParentTypes['DoctorsConnection'] = ResolversParentTypes['DoctorsConnection']> = ResolversObject<{
+  pageInfo: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
+  edges: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['DoctorEdge']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -402,6 +520,14 @@ export type OfferedSlotResolvers<ContextType = Context, ParentType extends Resol
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type PageInfoResolvers<ContextType = Context, ParentType extends ResolversParentTypes['PageInfo'] = ResolversParentTypes['PageInfo']> = ResolversObject<{
+  hasNextPage: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  hasPreviousPage: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  startCursor: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  endCursor: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type PatientResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Patient'] = ResolversParentTypes['Patient']> = ResolversObject<{
   id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   firstname: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -415,6 +541,18 @@ export type PatientResolvers<ContextType = Context, ParentType extends Resolvers
   allergies: Resolver<ReadonlyArray<ResolversTypes['String']>, ParentType, ContextType>;
   surgeries: Resolver<ReadonlyArray<ResolversTypes['String']>, ParentType, ContextType>;
   isSmoker: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type PatientEdgeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['PatientEdge'] = ResolversParentTypes['PatientEdge']> = ResolversObject<{
+  cursor: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes['Patient']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type PatientsConnectionResolvers<ContextType = Context, ParentType extends ResolversParentTypes['PatientsConnection'] = ResolversParentTypes['PatientsConnection']> = ResolversObject<{
+  pageInfo: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
+  edges: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['PatientEdge']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -433,8 +571,32 @@ export type ReviewResolvers<ContextType = Context, ParentType extends ResolversP
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type ReviewEdgeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ReviewEdge'] = ResolversParentTypes['ReviewEdge']> = ResolversObject<{
+  cursor: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes['Review']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ReviewsConnectionResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ReviewsConnection'] = ResolversParentTypes['ReviewsConnection']> = ResolversObject<{
+  pageInfo: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
+  edges: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ReviewEdge']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type ServiceResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Service'] = ResolversParentTypes['Service']> = ResolversObject<{
   id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ServiceEdgeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ServiceEdge'] = ResolversParentTypes['ServiceEdge']> = ResolversObject<{
+  cursor: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes['Service']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ServicesConnectionResolvers<ContextType = Context, ParentType extends ResolversParentTypes['ServicesConnection'] = ResolversParentTypes['ServicesConnection']> = ResolversObject<{
+  pageInfo: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
+  edges: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ServiceEdge']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -455,6 +617,18 @@ export type UserResolvers<ContextType = Context, ParentType extends ResolversPar
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type UserEdgeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['UserEdge'] = ResolversParentTypes['UserEdge']> = ResolversObject<{
+  cursor: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type UsersConnectionResolvers<ContextType = Context, ParentType extends ResolversParentTypes['UsersConnection'] = ResolversParentTypes['UsersConnection']> = ResolversObject<{
+  pageInfo: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
+  edges: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['UserEdge']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type WeekdayResolvers = EnumResolverSignature<{ Monday: any, Tuesday: any, Wednesday: any, Thursday: any, Friday: any, Saturday: any, Sunday: any }, ResolversTypes['Weekday']>;
 
 export interface WeightScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Weight'], any> {
@@ -465,10 +639,14 @@ export type Resolvers<ContextType = Context> = ResolversObject<{
   ActivityLevel: ActivityLevelResolvers;
   Address: AddressResolvers<ContextType>;
   Appointment: AppointmentResolvers<ContextType>;
+  AppointmentEdge: AppointmentEdgeResolvers<ContextType>;
   AppointmentTime: AppointmentTimeResolvers<ContextType>;
+  AppointmentsConnection: AppointmentsConnectionResolvers<ContextType>;
   Checkup: CheckupResolvers<ContextType>;
   DateTime: GraphQLScalarType;
   Doctor: DoctorResolvers<ContextType>;
+  DoctorEdge: DoctorEdgeResolvers<ContextType>;
+  DoctorsConnection: DoctorsConnectionResolvers<ContextType>;
   Duration: GraphQLScalarType;
   Followup: FollowupResolvers<ContextType>;
   Gender: GenderResolvers;
@@ -476,13 +654,22 @@ export type Resolvers<ContextType = Context> = ResolversObject<{
   Length: GraphQLScalarType;
   Node: NodeResolvers<ContextType>;
   OfferedSlot: OfferedSlotResolvers<ContextType>;
+  PageInfo: PageInfoResolvers<ContextType>;
   Patient: PatientResolvers<ContextType>;
+  PatientEdge: PatientEdgeResolvers<ContextType>;
+  PatientsConnection: PatientsConnectionResolvers<ContextType>;
   Query: QueryResolvers<ContextType>;
   Review: ReviewResolvers<ContextType>;
+  ReviewEdge: ReviewEdgeResolvers<ContextType>;
+  ReviewsConnection: ReviewsConnectionResolvers<ContextType>;
   Service: ServiceResolvers<ContextType>;
+  ServiceEdge: ServiceEdgeResolvers<ContextType>;
+  ServicesConnection: ServicesConnectionResolvers<ContextType>;
   Time: GraphQLScalarType;
   URL: GraphQLScalarType;
   User: UserResolvers<ContextType>;
+  UserEdge: UserEdgeResolvers<ContextType>;
+  UsersConnection: UsersConnectionResolvers<ContextType>;
   Weekday: WeekdayResolvers;
   Weight: GraphQLScalarType;
 }>;


### PR DESCRIPTION
Supports paginating over:
- users
- reviews
- patients
- doctors
- services
- appointments

For pagination we use the [standard cursor based pagination recommended by relay](https://relay.dev/graphql/connections.htm)
So we use the arguments: first, last, before, and after to figure out what part of the query to display.

We can create a paginated response from a query an array. See query.ts for examples of how to return paginated responses

# Test
We can now read all the users registered on our platform:

```graphql
{
  users {
    pageInfo {
      endCursor
      hasNextPage
    }
    edges {
      node {
        firstname
        lastname
      }
    }
  }
}
```

```json
{
  "data": {
    "users": {
      "pageInfo": {
        "endCursor": "bW9uZ29kYmNvbm5lY3Rpb246MTk=",
        "hasNextPage": false
      },
      "edges": [
        {
          "node": {
            "firstname": "Fabio",
            "lastname": "Kerekes"
          }
        },
        ...
      ]
    }
  }
}
```

<img width="1503" alt="Screen Shot 2021-06-09 at 2 22 38 PM" src="https://user-images.githubusercontent.com/13184158/121353438-27e61200-c92e-11eb-90a3-f5e7b970569f.png">
