### PR TITLE
Refactor Search Connection

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -49,3 +49,4 @@ generates:
         PatientEdge: pagination#PatientEdge
         ServiceEdge: pagination#ServiceEdge
         AppointmentEdge: pagination#AppointmentEdge
+        Search: search/types#SearchObject

--- a/src/resolvers/query.ts
+++ b/src/resolvers/query.ts
@@ -1,5 +1,5 @@
 
-import type { QueryResolvers } from '@resolvers';
+import type { QueryResolvers, QuerySearchArgs } from '@resolvers';
 import type { IReview } from 'models/Review';
 
 import Appointment from 'models/Appointment';
@@ -52,7 +52,7 @@ const Query: QueryResolvers = {
     async me(_, __, { authenticated }) {
         return authenticated;
     },
-    async node(_, { id: nodeId }) {
+    async node(_, { id: nodeId }, context) {
         const deconstructed = deconstructId(nodeId);
         if (deconstructed == null) {
             return null;
@@ -73,6 +73,10 @@ const Query: QueryResolvers = {
             return await patient(id);
         case 'Review':
             return await review(id);
+        case 'Search': {
+            const input = JSON.parse(id) as QuerySearchArgs;
+            return await search(input, context);
+        }
         case 'Service':
             return await service(id);
         case 'User':
@@ -85,26 +89,8 @@ const Query: QueryResolvers = {
     async reviews(_, args) {
         return await reviewsConnection(ReviewModel.find(), args);
     },
-    async search(_, { input, ...connectionArgs }, context) {
-        const [doctors, scope, suggestions] = await search({
-            cities: input.cities != null ? [...input.cities] : undefined,
-            query: input.query ?? undefined,
-            specialities: input.specialities != null ? [...input.specialities] : undefined,
-        }, context);
-
-        const results = await doctorsConnection(doctors, connectionArgs);
-        return {
-            results,
-            scope: {
-                cities: scope?.cities ?? null,
-                query: scope?.query ?? null,
-                specialities: scope.specialities ?? null,
-            },
-            suggestions: {
-                cities: suggestions.cities ?? null,
-                specialities: suggestions.specialities ?? null,
-            },
-        };
+    async search(_, input, context) {
+        return await search(input, context);
     },
     async services(_, args) {
         return await servicesConnection(Service.find(), args);

--- a/src/resolvers/search.ts
+++ b/src/resolvers/search.ts
@@ -1,14 +1,39 @@
 import type { SearchResolvers } from '@resolvers';
 
+import { doctorsConnection } from 'pagination';
+import { buildId } from 'utils/ids';
+
 const Search: SearchResolvers = {
-    results({ results }) {
-        return results;
+    id({ input }) {
+        const inputAsRecord = input as Record<string, unknown>;
+        const orderedInput = Object.keys(inputAsRecord).sort().reduce(
+            (obj, key) => {
+                return {
+                    ...obj,
+                    [key]: inputAsRecord[key],
+                };
+            },
+            {},
+        );
+
+        const stringified = JSON.stringify(orderedInput);
+        return buildId('Search', stringified);
+    },
+    results({ query }, connectionArgs) {
+        return doctorsConnection(query, connectionArgs);
     },
     scope({ scope }) {
-        return scope;
+        return {
+            cities: scope?.cities ?? null,
+            query: scope?.query ?? null,
+            specialities: scope.specialities ?? null,
+        };
     },
     suggestions({ suggestions }) {
-        return suggestions;
+        return {
+            cities: suggestions.cities ?? null,
+            specialities: suggestions.specialities ?? null,
+        };
     },
 };
 

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -1,7 +1,8 @@
 
+import type { QuerySearchArgs, RequireFields } from '@resolvers';
 import type { Context } from 'context';
 import type { IDoctor } from 'models/Doctor';
-import type { FilterQuery } from 'mongoose';
+import type { FilterQuery, Query } from 'mongoose';
 
 export type AppliedFilters = {
     readonly specialities?: string[]
@@ -25,4 +26,12 @@ export type SmartFilter = {
 
 export type SmartSuggestions = {
     create: (scope: Scope, context: Context) => Promise<Suggestions | null>;
+}
+
+export type SearchObject = {
+    __typename: 'Search',
+    input: RequireFields<QuerySearchArgs, never>,
+    query: Query<IDoctor[], IDoctor>,
+    scope: Scope
+    suggestions: Suggestions
 }

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -230,12 +230,6 @@ export const typeDefs = gql`
         edges: [AppointmentEdge]
     }
 
-    input SearchInput {
-        query: String
-        specialities: [String!]
-        cities: [String!]
-    }
-
     type SearchScope {
         query: String
         specialities: [String!]
@@ -247,10 +241,18 @@ export const typeDefs = gql`
         cities: [String!]
     }
 
-    type Search {
+    type Search implements Node {
+        id: ID!
+        
         scope: SearchScope!
         suggestions: SearchSuggestions!
-        results: DoctorsConnection!
+
+        results(
+            after: String, 
+            first: Int, 
+            before: String, 
+            last: Int,
+        ): DoctorsConnection!
     }
 
     input AddressInput {
@@ -286,11 +288,9 @@ export const typeDefs = gql`
         node(id: ID!): Node
 
         search(
-            input: SearchInput!,
-            after: String, 
-            first: Int, 
-            before: String, 
-            last: Int,
+            query: String
+            specialities: [String!]
+            cities: [String!]
         ): Search!
 
         users(after: String, first: Int, before: String, last: Int): UsersConnection!

--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -7,6 +7,7 @@ const nodeTypesTuple = <const> [
     'Followup',
     'Patient',
     'Review',
+    'Search',
     'Service',
     'User',
 ];

--- a/src/utils/resolvers.ts
+++ b/src/utils/resolvers.ts
@@ -11,6 +11,7 @@ import type { IFollowup as IFollowupModel } from 'models/Followup';
 import type { Review as ReviewModel } from 'shims/review';
 import type { Service as ServiceModel } from 'shims/service';
 import type { PageInfo as PageInfoModel, ReviewsConnection as ReviewsConnectionModel, UsersConnection as UsersConnectionModel, DoctorsConnection as DoctorsConnectionModel, PatientsConnection as PatientsConnectionModel, ServicesConnection as ServicesConnectionModel, AppointmentsConnection as AppointmentsConnectionModel, ReviewEdge as ReviewEdgeModel, UserEdge as UserEdgeModel, DoctorEdge as DoctorEdgeModel, PatientEdge as PatientEdgeModel, ServiceEdge as ServiceEdgeModel, AppointmentEdge as AppointmentEdgeModel } from 'pagination';
+import type { SearchObject as SearchObjectModel } from 'search/types';
 import type { Context } from 'context';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -29,7 +30,6 @@ export type Scalars = {
   DateTime: Date;
   Duration: number;
   Length: number;
-  Time: string;
   URL: string;
   Weight: number;
 };
@@ -214,11 +214,9 @@ export type QueryNodeArgs = {
 
 
 export type QuerySearchArgs = {
-  input: SearchInput;
-  after: Maybe<Scalars['String']>;
-  first: Maybe<Scalars['Int']>;
-  before: Maybe<Scalars['String']>;
-  last: Maybe<Scalars['Int']>;
+  query: Maybe<Scalars['String']>;
+  specialities: Maybe<ReadonlyArray<Scalars['String']>>;
+  cities: Maybe<ReadonlyArray<Scalars['String']>>;
 };
 
 
@@ -279,16 +277,19 @@ export type ReviewsConnection = {
   readonly edges: Maybe<ReadonlyArray<Maybe<ReviewEdge>>>;
 };
 
-export type Search = {
+export type Search = Node & {
+  readonly id: Scalars['ID'];
   readonly scope: SearchScope;
   readonly suggestions: SearchSuggestions;
   readonly results: DoctorsConnection;
 };
 
-export type SearchInput = {
-  readonly query: Maybe<Scalars['String']>;
-  readonly specialities: Maybe<ReadonlyArray<Scalars['String']>>;
-  readonly cities: Maybe<ReadonlyArray<Scalars['String']>>;
+
+export type SearchResultsArgs = {
+  after: Maybe<Scalars['String']>;
+  first: Maybe<Scalars['Int']>;
+  before: Maybe<Scalars['String']>;
+  last: Maybe<Scalars['Int']>;
 };
 
 export type SearchScope = {
@@ -315,7 +316,6 @@ export type ServicesConnection = {
   readonly pageInfo: PageInfo;
   readonly edges: Maybe<ReadonlyArray<Maybe<ServiceEdge>>>;
 };
-
 
 
 export type User = Node & {
@@ -461,7 +461,7 @@ export type ResolversTypes = ResolversObject<{
   Insurance: ResolverTypeWrapper<InsuranceModel>;
   Length: ResolverTypeWrapper<Scalars['Length']>;
   Mutation: ResolverTypeWrapper<{}>;
-  Node: ResolversTypes['Appointment'] | ResolversTypes['Checkup'] | ResolversTypes['Doctor'] | ResolversTypes['Followup'] | ResolversTypes['Patient'] | ResolversTypes['Review'] | ResolversTypes['Service'] | ResolversTypes['User'];
+  Node: ResolversTypes['Appointment'] | ResolversTypes['Checkup'] | ResolversTypes['Doctor'] | ResolversTypes['Followup'] | ResolversTypes['Patient'] | ResolversTypes['Review'] | ResolversTypes['Search'] | ResolversTypes['Service'] | ResolversTypes['User'];
   OfferedSlot: ResolverTypeWrapper<Omit<OfferedSlot, 'day'> & { day: ResolversTypes['Weekday'] }>;
   OfferedSlotInput: OfferedSlotInput;
   PageInfo: ResolverTypeWrapper<PageInfoModel>;
@@ -472,14 +472,12 @@ export type ResolversTypes = ResolversObject<{
   Review: ResolverTypeWrapper<ReviewModel>;
   ReviewEdge: ResolverTypeWrapper<ReviewEdgeModel>;
   ReviewsConnection: ResolverTypeWrapper<ReviewsConnectionModel>;
-  Search: ResolverTypeWrapper<Omit<Search, 'results'> & { results: ResolversTypes['DoctorsConnection'] }>;
-  SearchInput: SearchInput;
+  Search: ResolverTypeWrapper<SearchObjectModel>;
   SearchScope: ResolverTypeWrapper<SearchScope>;
   SearchSuggestions: ResolverTypeWrapper<SearchSuggestions>;
   Service: ResolverTypeWrapper<ServiceModel>;
   ServiceEdge: ResolverTypeWrapper<ServiceEdgeModel>;
   ServicesConnection: ResolverTypeWrapper<ServicesConnectionModel>;
-  Time: ResolverTypeWrapper<Scalars['Time']>;
   URL: ResolverTypeWrapper<Scalars['URL']>;
   User: ResolverTypeWrapper<UserModel>;
   UserDoctorInput: UserDoctorInput;
@@ -511,7 +509,7 @@ export type ResolversParentTypes = ResolversObject<{
   Followup: IFollowupModel;
   Length: Scalars['Length'];
   Mutation: {};
-  Node: ResolversParentTypes['Appointment'] | ResolversParentTypes['Checkup'] | ResolversParentTypes['Doctor'] | ResolversParentTypes['Followup'] | ResolversParentTypes['Patient'] | ResolversParentTypes['Review'] | ResolversParentTypes['Service'] | ResolversParentTypes['User'];
+  Node: ResolversParentTypes['Appointment'] | ResolversParentTypes['Checkup'] | ResolversParentTypes['Doctor'] | ResolversParentTypes['Followup'] | ResolversParentTypes['Patient'] | ResolversParentTypes['Review'] | ResolversParentTypes['Search'] | ResolversParentTypes['Service'] | ResolversParentTypes['User'];
   OfferedSlot: Omit<OfferedSlot, 'day'> & { day: ResolversParentTypes['Weekday'] };
   OfferedSlotInput: OfferedSlotInput;
   PageInfo: PageInfoModel;
@@ -522,14 +520,12 @@ export type ResolversParentTypes = ResolversObject<{
   Review: ReviewModel;
   ReviewEdge: ReviewEdgeModel;
   ReviewsConnection: ReviewsConnectionModel;
-  Search: Omit<Search, 'results'> & { results: ResolversParentTypes['DoctorsConnection'] };
-  SearchInput: SearchInput;
+  Search: SearchObjectModel;
   SearchScope: SearchScope;
   SearchSuggestions: SearchSuggestions;
   Service: ServiceModel;
   ServiceEdge: ServiceEdgeModel;
   ServicesConnection: ServicesConnectionModel;
-  Time: Scalars['Time'];
   URL: Scalars['URL'];
   User: UserModel;
   UserDoctorInput: UserDoctorInput;
@@ -643,7 +639,7 @@ export type MutationResolvers<ContextType = Context, ParentType extends Resolver
 }>;
 
 export type NodeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Appointment' | 'Checkup' | 'Doctor' | 'Followup' | 'Patient' | 'Review' | 'Service' | 'User', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'Appointment' | 'Checkup' | 'Doctor' | 'Followup' | 'Patient' | 'Review' | 'Search' | 'Service' | 'User', ParentType, ContextType>;
 }>;
 
 export type OfferedSlotResolvers<ContextType = Context, ParentType extends ResolversParentTypes['OfferedSlot'] = ResolversParentTypes['OfferedSlot']> = ResolversObject<{
@@ -693,7 +689,7 @@ export type QueryResolvers<ContextType = Context, ParentType extends ResolversPa
   greeting: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   me: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   node: Resolver<Maybe<ResolversTypes['Node']>, ParentType, ContextType, RequireFields<QueryNodeArgs, 'id'>>;
-  search: Resolver<ResolversTypes['Search'], ParentType, ContextType, RequireFields<QuerySearchArgs, 'input'>>;
+  search: Resolver<ResolversTypes['Search'], ParentType, ContextType, RequireFields<QuerySearchArgs, never>>;
   users: Resolver<ResolversTypes['UsersConnection'], ParentType, ContextType, RequireFields<QueryUsersArgs, never>>;
   patients: Resolver<ResolversTypes['PatientsConnection'], ParentType, ContextType, RequireFields<QueryPatientsArgs, never>>;
   doctors: Resolver<ResolversTypes['DoctorsConnection'], ParentType, ContextType, RequireFields<QueryDoctorsArgs, never>>;
@@ -724,9 +720,10 @@ export type ReviewsConnectionResolvers<ContextType = Context, ParentType extends
 }>;
 
 export type SearchResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Search'] = ResolversParentTypes['Search']> = ResolversObject<{
+  id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   scope: Resolver<ResolversTypes['SearchScope'], ParentType, ContextType>;
   suggestions: Resolver<ResolversTypes['SearchSuggestions'], ParentType, ContextType>;
-  results: Resolver<ResolversTypes['DoctorsConnection'], ParentType, ContextType>;
+  results: Resolver<ResolversTypes['DoctorsConnection'], ParentType, ContextType, RequireFields<SearchResultsArgs, never>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -759,10 +756,6 @@ export type ServicesConnectionResolvers<ContextType = Context, ParentType extend
   edges: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ServiceEdge']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
-
-export interface TimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Time'], any> {
-  name: 'Time';
-}
 
 export interface UrlScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['URL'], any> {
   name: 'URL';
@@ -829,7 +822,6 @@ export type Resolvers<ContextType = Context> = ResolversObject<{
   Service: ServiceResolvers<ContextType>;
   ServiceEdge: ServiceEdgeResolvers<ContextType>;
   ServicesConnection: ServicesConnectionResolvers<ContextType>;
-  Time: GraphQLScalarType;
   URL: GraphQLScalarType;
   User: UserResolvers<ContextType>;
   UserEdge: UserEdgeResolvers<ContextType>;


### PR DESCRIPTION
While trying to integrate search into the frontend I noticed that relay connections need the arguments to be on the field that returns the connection. This PR moves the arguments down (breaking change!) and makes search implement node for easier refresh for pagination.